### PR TITLE
Add change time for reserved activities and activity steps

### DIFF
--- a/TRPCoreKit/TRPDataLayer/Domain/Models/AddPlan/TRPAddPlanData.swift
+++ b/TRPCoreKit/TRPDataLayer/Domain/Models/AddPlan/TRPAddPlanData.swift
@@ -58,6 +58,9 @@ public struct TRPAddPlanData {
     /// Available days from timeline/itinerary
     public var availableDays: [Date] = []
 
+    /// Segment index for edit mode (updating existing segment)
+    public var segmentIndex: Int?
+
     public init() {}
 }
 

--- a/TRPCoreKit/ViewController/TimelineItinerary/AddPlan/TimeSelection/AddPlanTimeSelectionVC.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/AddPlan/TimeSelection/AddPlanTimeSelectionVC.swift
@@ -26,6 +26,9 @@ public class AddPlanTimeSelectionVC: TRPBaseUIViewController, DynamicHeightPrese
     // Callback when segment creation completes successfully
     public var onSegmentCreated: (() -> Void)?
 
+    // Callback when segment update completes successfully (edit mode)
+    public var onSegmentUpdated: (() -> Void)?
+
     // MARK: - UI Components
     private var customNavigationBar: TRPTimelineCustomNavigationBar!
 
@@ -94,6 +97,13 @@ public class AddPlanTimeSelectionVC: TRPBaseUIViewController, DynamicHeightPrese
         self.viewModel.delegate = self
     }
 
+    /// Edit mode - for changing time of existing reserved activity
+    public init(segment: TRPTimelineSegment, planData: AddPlanData) {
+        super.init(nibName: nil, bundle: nil)
+        self.viewModel = AddPlanTimeSelectionViewModel(segment: segment, planData: planData)
+        self.viewModel.delegate = self
+    }
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -114,9 +124,11 @@ public class AddPlanTimeSelectionVC: TRPBaseUIViewController, DynamicHeightPrese
         view.backgroundColor = .white
 
         // Setup navigation bar using base class method
-        customNavigationBar = setupCustomNavigationBar(
-            title: AddPlanLocalizationKeys.localized(AddPlanLocalizationKeys.addPlan)
-        )
+        // Use different title for edit mode
+        let navTitle = viewModel.isEditMode
+            ? TimelineLocalizationKeys.localized(TimelineLocalizationKeys.changeTime)
+            : AddPlanLocalizationKeys.localized(AddPlanLocalizationKeys.addPlan)
+        customNavigationBar = setupCustomNavigationBar(title: navTitle)
         customNavigationBar.delegate = self
 
         view.addSubview(dayFilterView)
@@ -184,8 +196,12 @@ public class AddPlanTimeSelectionVC: TRPBaseUIViewController, DynamicHeightPrese
         // Call existing callback (for compatibility)
         onTimeSelected?(selectedDate, selectedTimeSlot)
 
-        // Create reserved_activity segment via ViewModel
-        viewModel.createReservedActivitySegment()
+        // Create or update segment based on mode
+        if viewModel.isEditMode {
+            viewModel.updateReservedActivitySegment()
+        } else {
+            viewModel.createReservedActivitySegment()
+        }
     }
 
     // MARK: - Helpers
@@ -277,6 +293,13 @@ extension AddPlanTimeSelectionVC: AddPlanTimeSelectionViewModelDelegate {
         // Dismiss and trigger timeline refresh
         dismiss(animated: true) { [weak self] in
             self?.onSegmentCreated?()
+        }
+    }
+
+    public func segmentUpdateDidSucceed() {
+        // Dismiss and trigger timeline refresh (edit mode)
+        dismiss(animated: true) { [weak self] in
+            self?.onSegmentUpdated?()
         }
     }
 }

--- a/TRPCoreKit/ViewController/TimelineItinerary/AddPlan/TimeSelection/AddPlanTimeSelectionVC.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/AddPlan/TimeSelection/AddPlanTimeSelectionVC.swift
@@ -29,6 +29,9 @@ public class AddPlanTimeSelectionVC: TRPBaseUIViewController, DynamicHeightPrese
     // Callback when segment update completes successfully (edit mode)
     public var onSegmentUpdated: (() -> Void)?
 
+    // Callback when step update completes successfully (step edit mode)
+    public var onStepUpdated: (() -> Void)?
+
     // MARK: - UI Components
     private var customNavigationBar: TRPTimelineCustomNavigationBar!
 
@@ -101,6 +104,13 @@ public class AddPlanTimeSelectionVC: TRPBaseUIViewController, DynamicHeightPrese
     public init(segment: TRPTimelineSegment, planData: AddPlanData) {
         super.init(nibName: nil, bundle: nil)
         self.viewModel = AddPlanTimeSelectionViewModel(segment: segment, planData: planData)
+        self.viewModel.delegate = self
+    }
+
+    /// Step edit mode - for changing time of activity steps in recommendations
+    public init(step: TRPTimelineStep, planData: AddPlanData) {
+        super.init(nibName: nil, bundle: nil)
+        self.viewModel = AddPlanTimeSelectionViewModel(step: step, planData: planData)
         self.viewModel.delegate = self
     }
 
@@ -196,10 +206,15 @@ public class AddPlanTimeSelectionVC: TRPBaseUIViewController, DynamicHeightPrese
         // Call existing callback (for compatibility)
         onTimeSelected?(selectedDate, selectedTimeSlot)
 
-        // Create or update segment based on mode
-        if viewModel.isEditMode {
+        // Create or update based on mode
+        if viewModel.isStepEditMode {
+            // Step edit mode - update activity step time
+            viewModel.updateActivityStep()
+        } else if viewModel.isEditMode {
+            // Segment edit mode - update reserved activity segment time
             viewModel.updateReservedActivitySegment()
         } else {
+            // Create mode - create new reserved activity segment
             viewModel.createReservedActivitySegment()
         }
     }
@@ -300,6 +315,13 @@ extension AddPlanTimeSelectionVC: AddPlanTimeSelectionViewModelDelegate {
         // Dismiss and trigger timeline refresh (edit mode)
         dismiss(animated: true) { [weak self] in
             self?.onSegmentUpdated?()
+        }
+    }
+
+    public func stepUpdateDidSucceed() {
+        // Dismiss and trigger timeline refresh (step edit mode)
+        dismiss(animated: true) { [weak self] in
+            self?.onStepUpdated?()
         }
     }
 }

--- a/TRPCoreKit/ViewController/TimelineItinerary/AddPlan/TimeSelection/AddPlanTimeSelectionViewModel.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/AddPlan/TimeSelection/AddPlanTimeSelectionViewModel.swift
@@ -15,6 +15,7 @@ public typealias TimeSlot = TRPTourScheduleSlot
 public protocol AddPlanTimeSelectionViewModelDelegate: ViewModelDelegate {
     func timeSlotsDidLoad()
     func segmentCreationDidSucceed()
+    func segmentUpdateDidSucceed()
 }
 
 public class AddPlanTimeSelectionViewModel {
@@ -30,12 +31,71 @@ public class AddPlanTimeSelectionViewModel {
     private var selectedDate: Date?
     private var selectedTimeSlot: TimeSlot?
 
+    // Edit mode properties
+    private var segment: TRPTimelineSegment?
+    public var isEditMode: Bool { segment != nil }
+
     // MARK: - Initialization
     public init(tour: TRPTourProduct, planData: AddPlanData, tourRepository: TourRepository = TRPTourRepository()) {
         self.tour = tour
         self.planData = planData
         self.tourRepository = tourRepository
         self.selectedDate = planData.selectedDay
+    }
+
+    /// Edit mode initializer - creates TRPTourProduct from segment's additionalData
+    public init(segment: TRPTimelineSegment, planData: AddPlanData, tourRepository: TourRepository = TRPTourRepository()) {
+        self.segment = segment
+        self.planData = planData
+        self.tourRepository = tourRepository
+        self.selectedDate = planData.selectedDay
+
+        // Extract tour info from segment's additionalData
+        guard let additionalData = segment.additionalData else {
+            fatalError("Reserved activity segment must have additionalData")
+        }
+
+        // Format productId for availability API
+        // If activityId doesn't start with "C_", format as "C_{activityId}_15_{cityId}"
+        let activityId = additionalData.activityId ?? ""
+        let cityId = segment.city?.id ?? planData.selectedCity?.id ?? 0
+        let formattedProductId: String
+        if activityId.hasPrefix("C_") {
+            formattedProductId = activityId
+        } else {
+            formattedProductId = "C_\(activityId)_15_\(cityId)"
+        }
+
+        // Create TRPTourProduct from additionalData (schedule API needs productId)
+        let tourImage: TRPImage? = additionalData.imageUrl != nil
+            ? TRPImage(url: additionalData.imageUrl!, imageOwner: nil, width: nil, height: nil)
+            : nil
+
+        self.tour = TRPTourProduct(
+            id: formattedProductId,
+            productId: formattedProductId,
+            cityId: cityId,
+            name: additionalData.title ?? "",
+            image: tourImage,
+            gallery: nil,
+            duration: additionalData.duration != nil ? Int(additionalData.duration!) : nil,
+            price: additionalData.price != nil ? Int(additionalData.price!.value) : nil,
+            rating: nil,
+            ratingCount: nil,
+            description: additionalData.description,
+            webUrl: nil,
+            phone: nil,
+            hours: nil,
+            address: nil,
+            icon: "",
+            coordinate: additionalData.coordinate,
+            categories: [],
+            tags: [],
+            distance: nil,
+            status: true,
+            offers: [],
+            additionalData: nil
+        )
     }
 
     // MARK: - Public Methods
@@ -215,6 +275,70 @@ public class AddPlanTimeSelectionViewModel {
                         self.delegate?.segmentCreationDidSucceed()
                     } else {
                         let error = NSError(domain: "AddPlanTimeSelection", code: -4, userInfo: [NSLocalizedDescriptionKey: "Failed to create reservation. Please try again."])
+                        self.delegate?.viewModel(error: error)
+                    }
+
+                case .failure(let error):
+                    self.delegate?.viewModel(error: error)
+                }
+            }
+        }
+    }
+
+    /// Update existing reserved activity segment (edit mode)
+    public func updateReservedActivitySegment() {
+        // 1. Validate required data
+        guard let tripHash = planData.tripHash else {
+            delegate?.viewModel(error: NSError(domain: "AddPlanTimeSelection", code: -1, userInfo: [NSLocalizedDescriptionKey: "Timeline not found. Please try again."]))
+            return
+        }
+
+        guard let segmentIndex = planData.segmentIndex,
+              let segment = segment else {
+            delegate?.viewModel(error: NSError(domain: "AddPlanTimeSelection", code: -2, userInfo: [NSLocalizedDescriptionKey: "Segment not found. Please try again."]))
+            return
+        }
+
+        guard let selectedDate = selectedDate,
+              let selectedTimeSlot = selectedTimeSlot else {
+            delegate?.viewModel(error: NSError(domain: "AddPlanTimeSelection", code: -3, userInfo: [NSLocalizedDescriptionKey: "Please select a time slot."]))
+            return
+        }
+
+        // 2. Calculate new times
+        let (startDateString, endDateString, startDatetimeString, endDatetimeString) = calculateSegmentTimes(
+            selectedDate: selectedDate,
+            selectedTimeSlot: selectedTimeSlot
+        )
+
+        // 3. Update additionalData times
+        var updatedAdditionalData = segment.additionalData
+        updatedAdditionalData?.startDatetime = startDatetimeString
+        updatedAdditionalData?.endDatetime = endDatetimeString
+
+        // 4. Create edit profile from existing segment
+        let profile = TRPCreateEditTimelineSegmentProfile(from: segment, tripHash: tripHash, segmentIndex: segmentIndex)
+        profile.startDate = startDateString
+        profile.endDate = endDateString
+        profile.additionalData = updatedAdditionalData
+
+        // 5. Show loading
+        delegate?.viewModel(showPreloader: true)
+
+        // 6. Update segment via repository
+        let repository = TRPTimelineRepository()
+        repository.createEditTimelineSegment(profile: profile) { [weak self] result in
+            guard let self = self else { return }
+
+            DispatchQueue.main.async {
+                self.delegate?.viewModel(showPreloader: false)
+
+                switch result {
+                case .success(let success):
+                    if success {
+                        self.delegate?.segmentUpdateDidSucceed()
+                    } else {
+                        let error = NSError(domain: "AddPlanTimeSelection", code: -4, userInfo: [NSLocalizedDescriptionKey: "Failed to update time. Please try again."])
                         self.delegate?.viewModel(error: error)
                     }
 

--- a/TRPCoreKit/ViewController/TimelineItinerary/AddPlan/TimeSelection/AddPlanTimeSelectionViewModel.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/AddPlan/TimeSelection/AddPlanTimeSelectionViewModel.swift
@@ -16,6 +16,7 @@ public protocol AddPlanTimeSelectionViewModelDelegate: ViewModelDelegate {
     func timeSlotsDidLoad()
     func segmentCreationDidSucceed()
     func segmentUpdateDidSucceed()
+    func stepUpdateDidSucceed()
 }
 
 public class AddPlanTimeSelectionViewModel {
@@ -33,7 +34,9 @@ public class AddPlanTimeSelectionViewModel {
 
     // Edit mode properties
     private var segment: TRPTimelineSegment?
-    public var isEditMode: Bool { segment != nil }
+    private var step: TRPTimelineStep?
+    public var isEditMode: Bool { segment != nil || step != nil }
+    public var isStepEditMode: Bool { step != nil }
 
     // MARK: - Initialization
     public init(tour: TRPTourProduct, planData: AddPlanData, tourRepository: TourRepository = TRPTourRepository()) {
@@ -94,6 +97,66 @@ public class AddPlanTimeSelectionViewModel {
             distance: nil,
             status: true,
             offers: [],
+            additionalData: nil
+        )
+    }
+
+    /// Step edit mode initializer - for changing time of activity steps in recommendations
+    public init(step: TRPTimelineStep, planData: AddPlanData, tourRepository: TourRepository = TRPTourRepository()) {
+        self.step = step
+        self.planData = planData
+        self.tourRepository = tourRepository
+        self.selectedDate = planData.selectedDay
+
+        // Extract product info from step's POI
+        guard let poi = step.poi else {
+            fatalError("Activity step must have POI")
+        }
+
+        // Get productId from POI's additionalData or bookings
+        let productId: String
+        if let additionalProductId = poi.additionalData?.productId {
+            productId = additionalProductId
+        } else if let bookingProduct = poi.bookings?.first?.firstProduct() {
+            productId = bookingProduct.id
+        } else {
+            productId = poi.id
+        }
+
+        // Format productId for availability API
+        // If productId doesn't start with "C_", format as "C_{productId}_15_{cityId}"
+        let cityId = planData.selectedCity?.id ?? poi.cityId
+        let formattedProductId: String
+        if productId.hasPrefix("C_") {
+            formattedProductId = productId
+        } else {
+            formattedProductId = "C_\(productId)_15_\(cityId)"
+        }
+
+        // Create TRPTourProduct from POI (schedule API needs productId)
+        self.tour = TRPTourProduct(
+            id: formattedProductId,
+            productId: formattedProductId,
+            cityId: cityId,
+            name: poi.name,
+            image: poi.image,
+            gallery: poi.gallery,
+            duration: poi.duration,
+            price: poi.price,
+            rating: poi.rating,
+            ratingCount: poi.ratingCount,
+            description: poi.description,
+            webUrl: poi.webUrl,
+            phone: poi.phone,
+            hours: poi.hours,
+            address: poi.address,
+            icon: poi.icon ?? "",
+            coordinate: poi.coordinate,
+            categories: poi.categories,
+            tags: poi.tags,
+            distance: poi.distance,
+            status: poi.status,
+            offers: poi.offers,
             additionalData: nil
         )
     }
@@ -349,6 +412,60 @@ public class AddPlanTimeSelectionViewModel {
         }
     }
 
+    /// Update activity step time (step edit mode)
+    public func updateActivityStep() {
+        guard let step = step else {
+            delegate?.viewModel(error: NSError(domain: "AddPlanTimeSelection", code: -1, userInfo: [NSLocalizedDescriptionKey: "Step not found. Please try again."]))
+            return
+        }
+
+        guard let selectedTimeSlot = selectedTimeSlot else {
+            delegate?.viewModel(error: NSError(domain: "AddPlanTimeSelection", code: -2, userInfo: [NSLocalizedDescriptionKey: "Please select a time slot."]))
+            return
+        }
+
+        // Get start time from time slot (format: "HH:mm" or "HH:mm:ss")
+        // Extract just the "HH:mm" part
+        let startTimeComponents = selectedTimeSlot.time.split(separator: ":")
+        guard startTimeComponents.count >= 2 else {
+            delegate?.viewModel(error: NSError(domain: "AddPlanTimeSelection", code: -3, userInfo: [NSLocalizedDescriptionKey: "Invalid time format."]))
+            return
+        }
+        let startTime = "\(startTimeComponents[0]):\(startTimeComponents[1])"
+
+        // Calculate end time based on duration
+        let durationMinutes = tour.duration ?? 60
+        let endTime = calculateEndTime(startTime: startTime, durationMinutes: durationMinutes)
+
+        // Create step edit request (only time, no date)
+        let stepEdit = TRPTimelineStepEdit(
+            stepId: step.id,
+            startTime: startTime,
+            endTime: endTime
+        )
+
+        // Show loading
+        delegate?.viewModel(showPreloader: true)
+
+        // Update step via repository
+        let repository = TRPTimelineStepRepository()
+        repository.editStep(step: stepEdit) { [weak self] result in
+            guard let self = self else { return }
+
+            DispatchQueue.main.async {
+                self.delegate?.viewModel(showPreloader: false)
+
+                switch result {
+                case .success:
+                    self.delegate?.stepUpdateDidSucceed()
+
+                case .failure(let error):
+                    self.delegate?.viewModel(error: error)
+                }
+            }
+        }
+    }
+
     // MARK: - Private Methods
 
     private func calculateSegmentTimes(
@@ -401,5 +518,22 @@ public class AddPlanTimeSelectionViewModel {
         let endDatetimeString = dateFormatter.string(from: end)
 
         return (startDateString, endDateString, startDatetimeString, endDatetimeString)
+    }
+
+    /// Calculate end time from start time and duration (returns "HH:mm" format)
+    private func calculateEndTime(startTime: String, durationMinutes: Int) -> String {
+        let components = startTime.split(separator: ":")
+        guard components.count >= 2,
+              let hour = Int(components[0]),
+              let minute = Int(components[1]) else {
+            // Fallback: add 1 hour to a default time
+            return "13:00"
+        }
+
+        let totalMinutes = hour * 60 + minute + durationMinutes
+        let endHour = (totalMinutes / 60) % 24
+        let endMinute = totalMinutes % 60
+
+        return String(format: "%02d:%02d", endHour, endMinute)
     }
 }

--- a/TRPCoreKit/ViewController/TimelineItinerary/Cells/TRPTimelineBookedActivityCell.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/Cells/TRPTimelineBookedActivityCell.swift
@@ -13,6 +13,7 @@ protocol TRPTimelineBookedActivityCellDelegate: AnyObject {
     func bookedActivityCellDidTapMoreOptions(_ cell: TRPTimelineBookedActivityCell)
     func bookedActivityCellDidTapReservation(_ cell: TRPTimelineBookedActivityCell, segment: TRPTimelineSegment)
     func bookedActivityCellDidTapRemove(_ cell: TRPTimelineBookedActivityCell, segment: TRPTimelineSegment)
+    func bookedActivityCellDidTapChangeTime(_ cell: TRPTimelineBookedActivityCell, segment: TRPTimelineSegment)
 }
 
 class TRPTimelineBookedActivityCell: UITableViewCell {
@@ -126,6 +127,17 @@ class TRPTimelineBookedActivityCell: UITableViewCell {
         return button
     }()
 
+    private lazy var changeTimeButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        let icon = TRPImageController().getImage(inFramework: "ic_change_time", inApp: nil)?.withRenderingMode(.alwaysTemplate)
+        button.setImage(icon, for: .normal)
+        button.tintColor = ColorSet.primary.uiColor
+        button.contentHorizontalAlignment = .trailing
+        button.addTarget(self, action: #selector(changeTimeButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
     private lazy var removeButton: UIButton = {
         let button = UIButton(type: .custom)
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -133,6 +145,16 @@ class TRPTimelineBookedActivityCell: UITableViewCell {
         button.contentHorizontalAlignment = .center
         button.addTarget(self, action: #selector(removeButtonTapped), for: .touchUpInside)
         return button
+    }()
+
+    // Action buttons container
+    private let actionButtonsStack: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .horizontal
+        stack.spacing = 4
+        stack.alignment = .center
+        return stack
     }()
 
 
@@ -187,8 +209,12 @@ class TRPTimelineBookedActivityCell: UITableViewCell {
 
         containerView.addSubview(activityImageView)
         containerView.addSubview(titleLabel)
-        containerView.addSubview(removeButton)
+        containerView.addSubview(actionButtonsStack)
         containerView.addSubview(rightContentStackView)
+
+        // Build action buttons stack
+        actionButtonsStack.addArrangedSubview(changeTimeButton)
+        actionButtonsStack.addArrangedSubview(removeButton)
 
         // Build person horizontal stack
         personStackView.addArrangedSubview(personIcon)
@@ -230,12 +256,16 @@ class TRPTimelineBookedActivityCell: UITableViewCell {
             // Title Label - top right area
             titleLabel.topAnchor.constraint(equalTo: containerView.topAnchor),
             titleLabel.leadingAnchor.constraint(equalTo: activityImageView.trailingAnchor, constant: 12),
-            titleLabel.trailingAnchor.constraint(equalTo: removeButton.leadingAnchor, constant: -8),
+            titleLabel.trailingAnchor.constraint(equalTo: actionButtonsStack.leadingAnchor, constant: -8),
 
-            // Remove button - fixed to right, aligned with title (wider tap area)
-            removeButton.topAnchor.constraint(equalTo: containerView.topAnchor),
-            removeButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-            removeButton.widthAnchor.constraint(equalToConstant: 44),
+            // Action buttons stack - fixed to right, aligned with title
+            actionButtonsStack.topAnchor.constraint(equalTo: containerView.topAnchor),
+            actionButtonsStack.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+
+            // Button sizes
+            changeTimeButton.widthAnchor.constraint(equalToConstant: 36),
+            changeTimeButton.heightAnchor.constraint(equalToConstant: 28),
+            removeButton.widthAnchor.constraint(equalToConstant: 40),
             removeButton.heightAnchor.constraint(equalToConstant: 28),
 
             // Right Content Stack View - below title
@@ -277,6 +307,7 @@ class TRPTimelineBookedActivityCell: UITableViewCell {
             confirmedBadge.textColor = ColorSet.fgOrange.uiColor
             confirmedBadge.backgroundColor = ColorSet.bgOrange.uiColor
             reservationButton.isHidden = false
+            changeTimeButton.isHidden = false
             removeButton.isHidden = false
             personStackView.isHidden = true
         } else {
@@ -285,6 +316,7 @@ class TRPTimelineBookedActivityCell: UITableViewCell {
             confirmedBadge.textColor = ColorSet.fgGreen.uiColor
             confirmedBadge.backgroundColor = ColorSet.bgGreen.uiColor
             reservationButton.isHidden = true
+            changeTimeButton.isHidden = true
             removeButton.isHidden = true
             personStackView.isHidden = false
         }
@@ -374,6 +406,7 @@ class TRPTimelineBookedActivityCell: UITableViewCell {
             confirmedBadge.textColor = ColorSet.fgOrange.uiColor
             confirmedBadge.backgroundColor = ColorSet.bgOrange.uiColor
             reservationButton.isHidden = false
+            changeTimeButton.isHidden = false
             removeButton.isHidden = false
             personStackView.isHidden = true
         } else {
@@ -382,6 +415,7 @@ class TRPTimelineBookedActivityCell: UITableViewCell {
             confirmedBadge.textColor = ColorSet.fgGreen.uiColor
             confirmedBadge.backgroundColor = ColorSet.bgGreen.uiColor
             reservationButton.isHidden = true
+            changeTimeButton.isHidden = true
             removeButton.isHidden = true
             personStackView.isHidden = false
         }
@@ -464,6 +498,11 @@ class TRPTimelineBookedActivityCell: UITableViewCell {
     @objc private func reservationButtonTapped() {
         guard let segment = segment else { return }
         delegate?.bookedActivityCellDidTapReservation(self, segment: segment)
+    }
+
+    @objc private func changeTimeButtonTapped() {
+        guard let segment = segment else { return }
+        delegate?.bookedActivityCellDidTapChangeTime(self, segment: segment)
     }
 
     @objc private func removeButtonTapped() {

--- a/TRPCoreKit/ViewController/TimelineItinerary/Cells/TRPTimelineRecommendationsCell.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/Cells/TRPTimelineRecommendationsCell.swift
@@ -456,7 +456,7 @@ class TRPTimelineRecommendationsCell: UITableViewCell {
         changeTimeButton.contentHorizontalAlignment = .trailing
         changeTimeButton.tag = steps.firstIndex(where: { $0.id == step.id }) ?? 0
         changeTimeButton.addTarget(self, action: #selector(changeTimeTapped(_:)), for: .touchUpInside)
-        changeTimeButton.isHidden = isActivity
+        // Show change time button for both POI and activity steps
 
         // Remove step button - 32x32, icon 20x20
         let removeStepButton = UIButton(type: .custom)

--- a/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC+CellDelegates.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC+CellDelegates.swift
@@ -243,6 +243,49 @@ extension TRPTimelineItineraryVC: TRPTimelineRecommendationsCellDelegate {
     }
 
     func recommendationsCellDidTapChangeTime(_ cell: TRPTimelineRecommendationsCell, step: TRPTimelineStep) {
+        // Check if this is an activity step
+        if step.stepType == "activity" {
+            // Activity step - use AddPlanTimeSelectionVC with availability API
+            openActivityTimeSelection(for: step, cell: cell)
+        } else {
+            // Regular POI step - use time range picker
+            openTimeRangeSelection(for: step)
+        }
+    }
+
+    /// Opens AddPlanTimeSelectionVC for activity steps (with availability API)
+    private func openActivityTimeSelection(for step: TRPTimelineStep, cell: TRPTimelineRecommendationsCell) {
+        // Create AddPlanData with timeline info for step edit mode
+        var planData = AddPlanData()
+        planData.tripHash = viewModel.getTripHash()
+        planData.availableDays = viewModel.getDayDates()
+        planData.travelers = 1 // Default, can be updated if needed
+
+        // Set selected city from step's POI
+        if let poi = step.poi {
+            planData.selectedCity = viewModel.getCities().first { $0.id == poi.cityId }
+        }
+
+        // Set selected day from current step's date
+        if let startDateTimes = step.startDateTimes,
+           let date = parseStepDateTime(startDateTimes) {
+            planData.selectedDay = date
+        }
+
+        // Create time selection VC in step edit mode
+        let timeSelectionVC = AddPlanTimeSelectionVC(step: step, planData: planData)
+
+        // Set callback for step update
+        timeSelectionVC.onStepUpdated = { [weak self] in
+            self?.refreshTimelineAfterSegmentCreation()
+        }
+
+        // Present as bottom sheet
+        presentVCWithModal(timeSelectionVC, onlyLarge: false, prefersGrabberVisible: false)
+    }
+
+    /// Opens TRPTimeRangeSelectionViewController for regular POI steps
+    private func openTimeRangeSelection(for step: TRPTimelineStep) {
         // Store the step being edited
         stepBeingEdited = step
 

--- a/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC+CellDelegates.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC+CellDelegates.swift
@@ -75,6 +75,35 @@ extension TRPTimelineItineraryVC: TRPTimelineBookedActivityCellDelegate {
             }
         )
     }
+
+    func bookedActivityCellDidTapChangeTime(_ cell: TRPTimelineBookedActivityCell, segment: TRPTimelineSegment) {
+        // Create AddPlanData with timeline info for edit mode
+        var planData = AddPlanData()
+        planData.tripHash = viewModel.getTripHash()
+        planData.availableDays = viewModel.getDayDates()
+        planData.selectedCity = segment.city
+        planData.travelers = segment.adults
+
+        // Set selected day from current segment's date
+        if let startDateStr = segment.startDate,
+           let date = parseSegmentDateTime(startDateStr) {
+            planData.selectedDay = date
+        }
+
+        // Find segment index for update API
+        planData.segmentIndex = viewModel.getSegmentIndex(for: segment)
+
+        // Create time selection VC in edit mode
+        let timeSelectionVC = AddPlanTimeSelectionVC(segment: segment, planData: planData)
+
+        // Set callback for segment update
+        timeSelectionVC.onSegmentUpdated = { [weak self] in
+            self?.refreshTimelineAfterSegmentCreation()
+        }
+
+        // Present as bottom sheet
+        presentVCWithModal(timeSelectionVC, onlyLarge: false, prefersGrabberVisible: false)
+    }
 }
 
 // MARK: - TRPTimelineActivityStepCellDelegate

--- a/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryViewModel.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryViewModel.swift
@@ -64,6 +64,17 @@ public class TRPTimelineItineraryViewModel {
         return timeline?.tripHash
     }
 
+    /// Get segment index for update API (edit mode)
+    /// Matches segment by startDate and activityId
+    public func getSegmentIndex(for segment: TRPTimelineSegment) -> Int? {
+        guard let timeline = timeline,
+              let tripProfile = timeline.tripProfile else { return nil }
+        return tripProfile.segments.firstIndex { s in
+            s.startDate == segment.startDate &&
+            s.additionalData?.activityId == segment.additionalData?.activityId
+        }
+    }
+
     // Track collapse state for each section (section index -> isExpanded)
     internal var sectionCollapseStates: [Int: Bool] = [:]
 

--- a/TRPCoreKit/ViewController/TimelineItinerary/TimelineLocalizationKeys.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/TimelineLocalizationKeys.swift
@@ -41,6 +41,7 @@ public struct TimelineLocalizationKeys {
     public static let pointOfInterest = "timeline.label.pointOfInterest"
     public static let unknown = "timeline.label.unknown"
     public static let unknownLocation = "timeline.label.unknownLocation"
+    public static let changeTime = "timeline.label.changeTime"
     // from is now in CommonLocalizationKeys
 
     // MARK: - Duration & Distance Formats
@@ -76,6 +77,7 @@ public struct TimelineLocalizationKeys {
         pointOfInterest: "Point of interest",
         unknown: "Unknown",
         unknownLocation: "Unknown Location",
+        changeTime: "Change Time",
         durationHours: "%dh",
         durationMinutes: "%dm",
         durationCombined: "%dh %dm",


### PR DESCRIPTION
## Summary
- Add change time button for reserved (non-booked) activities in timeline
- Add change time functionality for activity steps in recommendations
- Uses availability API to fetch available time slots
- Supports changing to different days (not just same day)

## Changes
### Reserved Activities (Segment Edit)
- Added changeTimeButton to TRPTimelineBookedActivityCell
- Added segment edit mode to AddPlanTimeSelectionVC/ViewModel
- Updates segment via createEditTimelineSegment API

### Activity Steps (Step Edit)  
- Show change time button for activity type steps in recommendations
- Added step edit mode to AddPlanTimeSelectionVC/ViewModel
- Updates step via TRPTimelineStepRepository.editStep() API
- Sends only time format (HH:mm) for step edit requests

## Test plan
- [ ] Test change time button appears for reserved activities
- [ ] Test change time button appears for activity steps in recommendations
- [ ] Test selecting different day and time slot
- [ ] Test timeline refreshes after time update
- [ ] Verify API calls use correct format (segment: datetime, step: time only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)