### PR TITLE
Add activity detail delegation for timeline cells

### DIFF
--- a/TRPCoreKit/Coordinaters/TRPTimelineCoordinator.swift
+++ b/TRPCoreKit/Coordinaters/TRPTimelineCoordinator.swift
@@ -340,7 +340,10 @@ extension TRPTimelineCoordinator: TRPTimelineItineraryVCDelegate {
     }
 
     public func timelineItineraryDidSelectBookedActivity(_ viewController: TRPTimelineItineraryVC, segment: TRPTimelineSegment) {
-        // TODO: Open booked activity detail view
+        guard let activityId = segment.additionalData?.activityId else {
+            return
+        }
+        TRPCoreKit.shared.delegate?.trpCoreKitDidRequestActivityDetail(activityId: activityId)
     }
 
     public func timelineItineraryAddButtonPressed(_ viewController: TRPTimelineItineraryVC, atSectionIndex: Int) {

--- a/TRPCoreKit/ViewController/TimelineItinerary/Cells/TRPTimelineBookedActivityCell.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/Cells/TRPTimelineBookedActivityCell.swift
@@ -14,6 +14,7 @@ protocol TRPTimelineBookedActivityCellDelegate: AnyObject {
     func bookedActivityCellDidTapReservation(_ cell: TRPTimelineBookedActivityCell, segment: TRPTimelineSegment)
     func bookedActivityCellDidTapRemove(_ cell: TRPTimelineBookedActivityCell, segment: TRPTimelineSegment)
     func bookedActivityCellDidTapChangeTime(_ cell: TRPTimelineBookedActivityCell, segment: TRPTimelineSegment)
+    func bookedActivityCellDidTapCell(_ cell: TRPTimelineBookedActivityCell, segment: TRPTimelineSegment)
 }
 
 class TRPTimelineBookedActivityCell: UITableViewCell {
@@ -231,6 +232,11 @@ class TRPTimelineBookedActivityCell: UITableViewCell {
         rightContentStackView.addArrangedSubview(priceLabel)
         rightContentStackView.addArrangedSubview(cancellationLabel)
         rightContentStackView.addArrangedSubview(reservationButton)
+
+        // Add tap gesture for cell selection (entire cell except buttons)
+        let cellTapGesture = UITapGestureRecognizer(target: self, action: #selector(cellTapped))
+        cellTapGesture.delegate = self
+        contentView.addGestureRecognizer(cellTapGesture)
 
         setupConstraints()
     }
@@ -508,6 +514,11 @@ class TRPTimelineBookedActivityCell: UITableViewCell {
     @objc private func removeButtonTapped() {
         guard let segment = segment else { return }
         delegate?.bookedActivityCellDidTapRemove(self, segment: segment)
+    }
+
+    @objc private func cellTapped() {
+        guard let segment = segment else { return }
+        delegate?.bookedActivityCellDidTapCell(self, segment: segment)
     }
 }
 

--- a/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineFromItineraryViewModel.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineFromItineraryViewModel.swift
@@ -27,32 +27,133 @@ public class TRPTimelineFromItineraryViewModel {
     
     private var itineraryModel: TRPItineraryWithActivities
     private var tryCount = 0
-    
+
+    // City resolution
+    private let cityRemoteApi: TRPCityRemoteApi
+
     // MARK: - Initialization
-    public init(itineraryModel: TRPItineraryWithActivities) {
+    public init(itineraryModel: TRPItineraryWithActivities,
+                cityRemoteApi: TRPCityRemoteApi = TRPCityRemoteApi()) {
         self.itineraryModel = itineraryModel
+        self.cityRemoteApi = cityRemoteApi
     }
     
     // MARK: - Public Methods
-    
+
     /// Creates a timeline from the itinerary model
     /// Similar to createTrip() in CreateTripContainerViewModel
     public func createTimeline() {
-        // Convert itinerary to timeline profile
-        let timelineProfile = itineraryModel.createTimelineProfileFromBookings()
-        
         // Show loader
         delegate?.viewModel(showPreloader: true)
-        
+
+        // Debug: Log destination items
+        Log.i("TRPTimelineFromItineraryViewModel: destinationItems count = \(itineraryModel.destinationItems.count)")
+        for (index, item) in itineraryModel.destinationItems.enumerated() {
+            Log.i("TRPTimelineFromItineraryViewModel: destinationItems[\(index)] - title: \(item.title), cityId: \(String(describing: item.cityId)), coordinate: \(item.coordinate)")
+        }
+
+        // Check for missing or invalid cityIds in destination items
+        // cityId is invalid if it's nil, <= 0, or -1 (common placeholder value)
+        let itemsWithoutCityId = itineraryModel.destinationItems.enumerated()
+            .filter { $0.element.cityId == nil || ($0.element.cityId ?? 0) <= 0 }
+            .map { (index: $0.offset, item: $0.element) }
+
+        Log.i("TRPTimelineFromItineraryViewModel: itemsWithoutCityId count = \(itemsWithoutCityId.count)")
+
+        if itemsWithoutCityId.isEmpty {
+            // All have cityId, proceed directly
+            Log.i("TRPTimelineFromItineraryViewModel: All items have cityId, proceeding directly")
+            createTimelineInternal()
+        } else {
+            // Resolve cities first
+            Log.i("TRPTimelineFromItineraryViewModel: Resolving \(itemsWithoutCityId.count) missing cityIds")
+            resolveMissingCities(itemsWithoutCityId) { [weak self] in
+                self?.createTimelineInternal()
+            }
+        }
+    }
+
+    // MARK: - City Resolution
+
+    /// Resolves missing cityIds for destination items
+    /// Uses API first, then falls back to local cache if API fails
+    private func resolveMissingCities(_ items: [(index: Int, item: TRPSegmentDestinationItem)],
+                                      completion: @escaping () -> Void) {
+        let coordinates = items.map { parseCoordinate(from: $0.item.coordinate) }
+
+        Log.i("TRPTimelineFromItineraryViewModel: Calling resolveCities API with \(coordinates.count) coordinates")
+        for (index, coord) in coordinates.enumerated() {
+            Log.i("TRPTimelineFromItineraryViewModel: coordinate[\(index)] = lat: \(coord.lat), lon: \(coord.lon)")
+        }
+
+        // Try API first (more accurate)
+        cityRemoteApi.resolveCities(coordinates: coordinates) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let cityIds):
+                Log.i("TRPTimelineFromItineraryViewModel: resolveCities API success - cityIds: \(cityIds)")
+                // Update destination items with resolved cityIds
+                self.updateDestinationItemsCityIds(items: items, cityIds: cityIds)
+                completion()
+
+            case .failure(let error):
+                Log.e("TRPTimelineFromItineraryViewModel: resolveCities API failed - \(error.localizedDescription)")
+                // Fallback: Use TRPCityCache (local Haversine distance calculation)
+                Log.i("TRPTimelineFromItineraryViewModel: Using cache fallback")
+                self.resolveCitiesFromCache(items: items)
+                completion()
+            }
+        }
+    }
+
+    /// Fallback method to resolve cities from local cache using coordinate proximity
+    private func resolveCitiesFromCache(items: [(index: Int, item: TRPSegmentDestinationItem)]) {
+        for (index, item) in items {
+            let coordinate = parseCoordinate(from: item.coordinate)
+            if let city = TRPCityCache.shared.getCityByCoordinate(coordinate, maxDistanceKm: 100) {
+                itineraryModel.destinationItems[index].cityId = city.id
+            }
+        }
+    }
+
+    /// Updates destination items with resolved cityIds from API response
+    private func updateDestinationItemsCityIds(items: [(index: Int, item: TRPSegmentDestinationItem)],
+                                               cityIds: [Int]) {
+        for (i, (index, _)) in items.enumerated() {
+            if i < cityIds.count {
+                itineraryModel.destinationItems[index].cityId = cityIds[i]
+            }
+        }
+    }
+
+    /// Parses a coordinate string into TRPLocation
+    /// - Parameter coordinateString: String in format "lat,lon" (e.g., "41.3851,2.1734")
+    /// - Returns: TRPLocation with parsed coordinates, or (0,0) if parsing fails
+    private func parseCoordinate(from coordinateString: String) -> TRPLocation {
+        let parts = coordinateString.components(separatedBy: ",")
+        guard parts.count >= 2,
+              let lat = Double(parts[0].trimmingCharacters(in: .whitespaces)),
+              let lon = Double(parts[1].trimmingCharacters(in: .whitespaces)) else {
+            return TRPLocation(lat: 0, lon: 0)
+        }
+        return TRPLocation(lat: lat, lon: lon)
+    }
+
+    // MARK: - Timeline Creation
+
+    /// Internal method to create timeline after city resolution
+    private func createTimelineInternal() {
+        // Convert itinerary to timeline profile
+        let timelineProfile = itineraryModel.createTimelineProfileFromBookings()
+
         // Execute create timeline
         createTimelineUseCase?.executeCreateTimeline(profile: timelineProfile) { [weak self] result in
             guard let self = self else { return }
             self.timelineGenerationResult(result: result)
         }
     }
-    
-    // MARK: - Private Methods
-    
+
     /// Handles the result of timeline creation
     /// Similar to tripGenerationResult() in CreateTripContainerViewModel
     private func timelineGenerationResult(result: Result<TRPTimeline, Error>) {

--- a/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC+CellDelegates.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC+CellDelegates.swift
@@ -104,6 +104,14 @@ extension TRPTimelineItineraryVC: TRPTimelineBookedActivityCellDelegate {
         // Present as bottom sheet
         presentVCWithModal(timeSelectionVC, onlyLarge: false, prefersGrabberVisible: false)
     }
+
+    func bookedActivityCellDidTapCell(_ cell: TRPTimelineBookedActivityCell, segment: TRPTimelineSegment) {
+        // Open activity detail
+        guard let activityId = segment.additionalData?.activityId else {
+            return
+        }
+        TRPCoreKit.shared.delegate?.trpCoreKitDidRequestActivityDetail(activityId: activityId)
+    }
 }
 
 // MARK: - TRPTimelineActivityStepCellDelegate
@@ -234,9 +242,22 @@ extension TRPTimelineItineraryVC: TRPTimelineRecommendationsCellDelegate {
     }
 
     func recommendationsCellDidSelectStep(_ cell: TRPTimelineRecommendationsCell, step: TRPTimelineStep) {
-        // Open new POI detail view controller
         guard let poi = step.poi else { return }
 
+        // Activity step - call trpCoreKitDidRequestActivityDetail
+        if step.stepType == "activity" {
+            // Try booking product ID first, fallback to POI ID
+            let activityId: String
+            if let booking = poi.bookings?.first, let product = booking.firstProduct() {
+                activityId = product.id
+            } else {
+                activityId = poi.id
+            }
+            TRPCoreKit.shared.delegate?.trpCoreKitDidRequestActivityDetail(activityId: activityId)
+            return
+        }
+
+        // Normal POI step - open POI detail view controller
         let viewModel = TimelinePoiDetailViewModel(poi: poi)
         let detailVC = TimelinePoiDetailViewController(viewModel: viewModel)
         navigationController?.pushViewController(detailVC, animated: true)
@@ -335,20 +356,18 @@ extension TRPTimelineItineraryVC: TRPTimelineRecommendationsCellDelegate {
     }
 
     func recommendationsCellDidTapReservation(_ cell: TRPTimelineRecommendationsCell, step: TRPTimelineStep) {
-        // Handle reservation tap for activity steps
-        // Try to get product ID from POI's bookings first, fallback to POI id
+        // Handle reservation tap for activity steps - open activity detail
         guard let poi = step.poi else { return }
 
+        // Try to get product ID from POI's bookings first, fallback to POI id
         let activityId: String
         if let booking = poi.bookings?.first, let product = booking.firstProduct() {
             activityId = product.id
         } else {
-            // Fallback to POI id if no booking product available
             activityId = poi.id
         }
 
-        // Delegate to coordinator to open reservation flow
-        delegate?.timelineItineraryDidRequestActivityReservation(self, activityId: activityId)
+        TRPCoreKit.shared.delegate?.trpCoreKitDidRequestActivityDetail(activityId: activityId)
     }
 
     func recommendationsCellNeedsRouteCalculation(_ cell: TRPTimelineRecommendationsCell, locations: [TRPLocation], cellIndexPath: IndexPath) {

--- a/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryViewModel+TimelineOperations.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryViewModel+TimelineOperations.swift
@@ -17,6 +17,15 @@ extension TRPTimelineItineraryViewModel {
 
     /// Creates a new timeline from itinerary model
     internal func createTimeline(from itineraryModel: TRPItineraryWithActivities) {
+        // First, resolve missing cityIds in destination items
+        resolveMissingCityIds(in: itineraryModel) { [weak self] resolvedItineraryModel in
+            guard let self = self else { return }
+            self.createTimelineInternal(from: resolvedItineraryModel)
+        }
+    }
+
+    /// Internal method to create timeline after city resolution
+    private func createTimelineInternal(from itineraryModel: TRPItineraryWithActivities) {
         // Create timeline profile from itinerary
         let profile = itineraryModel.createTimelineProfileFromBookings()
 
@@ -43,6 +52,79 @@ extension TRPTimelineItineraryViewModel {
             }
         }
     }
+
+    // MARK: - City Resolution
+
+    /// Resolves missing or invalid cityIds in destination items
+    /// Uses API first, then falls back to local cache if API fails
+    private func resolveMissingCityIds(in itineraryModel: TRPItineraryWithActivities,
+                                       completion: @escaping (TRPItineraryWithActivities) -> Void) {
+        var mutableItinerary = itineraryModel
+
+        // Find items with missing or invalid cityIds (nil, <= 0)
+        let itemsWithoutCityId = mutableItinerary.destinationItems.enumerated()
+            .filter { $0.element.cityId == nil || ($0.element.cityId ?? 0) <= 0 }
+            .map { (index: $0.offset, item: $0.element) }
+
+        Log.i("TRPTimelineItineraryViewModel: Checking destination items for missing cityIds")
+        Log.i("TRPTimelineItineraryViewModel: Total destinations: \(mutableItinerary.destinationItems.count), missing cityIds: \(itemsWithoutCityId.count)")
+
+        // If all have valid cityId, proceed directly
+        if itemsWithoutCityId.isEmpty {
+            Log.i("TRPTimelineItineraryViewModel: All destination items have valid cityIds, proceeding")
+            completion(mutableItinerary)
+            return
+        }
+
+        // Parse coordinates for API call
+        let coordinates = itemsWithoutCityId.map { parseCoordinate(from: $0.item.coordinate) }
+
+        Log.i("TRPTimelineItineraryViewModel: Resolving \(itemsWithoutCityId.count) missing cityIds via API")
+        for (i, coord) in coordinates.enumerated() {
+            Log.i("TRPTimelineItineraryViewModel: coordinate[\(i)] = lat: \(coord.lat), lon: \(coord.lon)")
+        }
+
+        // Try API first (more accurate)
+        let cityRemoteApi = TRPCityRemoteApi()
+        cityRemoteApi.resolveCities(coordinates: coordinates) { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let cityIds):
+                Log.i("TRPTimelineItineraryViewModel: resolveCities API success - cityIds: \(cityIds)")
+                // Update destination items with resolved cityIds
+                for (i, (index, _)) in itemsWithoutCityId.enumerated() {
+                    if i < cityIds.count {
+                        mutableItinerary.destinationItems[index].cityId = cityIds[i]
+                        Log.i("TRPTimelineItineraryViewModel: Set destinationItems[\(index)].cityId = \(cityIds[i])")
+                    }
+                }
+                completion(mutableItinerary)
+
+            case .failure(let error):
+                Log.e("TRPTimelineItineraryViewModel: resolveCities API failed - \(error.localizedDescription)")
+                // Fallback: Use TRPCityCache (local Haversine distance calculation)
+                Log.i("TRPTimelineItineraryViewModel: Using cache fallback")
+                self.resolveCityIdsFromCache(items: itemsWithoutCityId, itinerary: &mutableItinerary)
+                completion(mutableItinerary)
+            }
+        }
+    }
+
+    /// Fallback method to resolve cities from local cache using coordinate proximity
+    private func resolveCityIdsFromCache(items: [(index: Int, item: TRPSegmentDestinationItem)],
+                                         itinerary: inout TRPItineraryWithActivities) {
+        for (index, item) in items {
+            let coordinate = parseCoordinate(from: item.coordinate)
+            if let city = TRPCityCache.shared.getCityByCoordinate(coordinate, maxDistanceKm: 100) {
+                itinerary.destinationItems[index].cityId = city.id
+                Log.i("TRPTimelineItineraryViewModel: Cache resolved destinationItems[\(index)].cityId = \(city.id) (\(city.name))")
+            } else {
+                Log.w("TRPTimelineItineraryViewModel: Could not resolve cityId for destinationItems[\(index)] from cache")
+            }
+        }
+    }
+
 
     /// Waits for timeline generation to complete
     internal func waitForTimelineGeneration(tripHash: String, itineraryModel: TRPItineraryWithActivities) {


### PR DESCRIPTION
## Summary
- Add `trpCoreKitDidRequestActivityDetail` call for reserved/booked activity cells when tapped
- Add tap gesture to `TRPTimelineBookedActivityCell` for cell-wide tap detection (excluding buttons)
- Update `recommendationsCellDidSelectStep` to handle activity steps separately from POI steps
- Update `recommendationsCellDidTapReservation` to call activity detail instead of reservation
- Add `bookedActivityCellDidTapCell` delegate method

## Test plan
- [ ] Tap on reserved activity cell (not on buttons) → should call `trpCoreKitDidRequestActivityDetail`
- [ ] Tap on booked activity cell → should call `trpCoreKitDidRequestActivityDetail`
- [ ] Tap on activity step in smart recommendations → should call `trpCoreKitDidRequestActivityDetail`
- [ ] Tap on reservation button in smart recommendations → should call `trpCoreKitDidRequestActivityDetail`
- [ ] Tap on normal POI step in smart recommendations → should open POI detail view
- [ ] Reservation, change time, and remove buttons should still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)