### PR TITLE
Fix activity ID handling and reservation button delegate

### DIFF
--- a/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC+CellDelegates.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC+CellDelegates.swift
@@ -347,10 +347,10 @@ extension TRPTimelineItineraryVC: TRPTimelineRecommendationsCellDelegate {
     }
 
     func recommendationsCellDidTapReservation(_ cell: TRPTimelineRecommendationsCell, step: TRPTimelineStep) {
-        // Handle reservation tap for activity steps - open activity detail
+        // Handle reservation tap for activity steps - open activity reservation
         guard let poi = step.poi else { return }
         let activityId = extractActivityId(from: poi)
-        TRPCoreKit.shared.delegate?.trpCoreKitDidRequestActivityDetail(activityId: activityId)
+        TRPCoreKit.shared.delegate?.trpCoreKitDidRequestActivityReservation(activityId: activityId)
     }
 
     func recommendationsCellNeedsRouteCalculation(_ cell: TRPTimelineRecommendationsCell, locations: [TRPLocation], cellIndexPath: IndexPath) {


### PR DESCRIPTION
## Summary
- Fix reservation button in smart recommendations calling wrong delegate method (was calling `trpCoreKitDidRequestActivityDetail` instead of `trpCoreKitDidRequestActivityReservation`)

## Test plan
- [ ] Tap on activity item in smart recommendations → should call `trpCoreKitDidRequestActivityDetail`
- [ ] Tap reservation button in smart recommendations → should call `trpCoreKitDidRequestActivityReservation`
- [ ] Verify activity IDs sent to delegate are clean (not starting with "C_")

🤖 Generated with [Claude Code](https://claude.com/claude-code)