### PR TITLE
UI fixes: POI ratings and map view improvements

### DIFF
--- a/TRPCoreKit/ViewController/TimelineItinerary/Cells/TRPTimelineActivityStepCell.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/Cells/TRPTimelineActivityStepCell.swift
@@ -182,25 +182,25 @@ class TRPTimelineActivityStepCell: UITableViewCell {
         // Configure title
         titleLabel.text = poi.name
         
-        // Configure rating if available
+        // Configure rating - Activity steps show rating
         ratingStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
-        
+
         if let rating = poi.rating {
             let ratingLabel = UILabel()
             ratingLabel.font = FontSet.montserratBold.font(14)
             ratingLabel.textColor = ColorSet.fg.uiColor
             ratingLabel.text = String(format: "%.1f", rating)
-            
+
             let starIcon = UIImageView()
             starIcon.image = TRPImageController().getImage(inFramework: "ic_rating_star", inApp: nil)
             starIcon.tintColor = ColorSet.ratingStar.uiColor
             starIcon.translatesAutoresizingMaskIntoConstraints = false
             starIcon.widthAnchor.constraint(equalToConstant: 12).isActive = true
             starIcon.heightAnchor.constraint(equalToConstant: 12).isActive = true
-            
+
             ratingStack.addArrangedSubview(ratingLabel)
             ratingStack.addArrangedSubview(starIcon)
-            
+
             if let reviewCount = poi.ratingCount {
                 let reviewLabel = UILabel()
                 reviewLabel.font = FontSet.montserratLight.font(14)

--- a/TRPCoreKit/ViewController/TimelineItinerary/Cells/TRPTimelineManualPoiCell.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/Cells/TRPTimelineManualPoiCell.swift
@@ -164,7 +164,7 @@ class TRPTimelineManualPoiCell: UITableViewCell {
     private let categoryBadge: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = ColorSet.bgBlue.uiColor
+        view.backgroundColor = ColorSet.neutral200.uiColor
         view.layer.cornerRadius = 4
         view.clipsToBounds = true
         return view
@@ -173,8 +173,8 @@ class TRPTimelineManualPoiCell: UITableViewCell {
     private let categoryLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = FontSet.montserratMedium.font(10)
-        label.textColor = ColorSet.fgBlue.uiColor
+        label.font = FontSet.montserratMedium.font(12)
+        label.textColor = ColorSet.fgGray.uiColor
         return label
     }()
 
@@ -321,20 +321,21 @@ class TRPTimelineManualPoiCell: UITableViewCell {
             poiImageView.image = nil
         }
 
-        // Configure rating
-        if let rating = poi?.rating {
-            ratingLabel.text = String(format: "%.1f", rating).replacingOccurrences(of: ".", with: ",")
-            ratingStackView.isHidden = false
-
-            if let ratingCount = poi?.ratingCount {
-                let opinionsText = AddPlanLocalizationKeys.localized(AddPlanLocalizationKeys.opinions)
-                reviewLabel.text = "\(ratingCount.formattedWithSeparator) \(opinionsText)"
-            } else {
-                reviewLabel.text = ""
-            }
-        } else {
-            ratingStackView.isHidden = true
-        }
+        // Configure rating - Hidden
+        ratingStackView.isHidden = true
+//        if let rating = poi?.rating {
+//            ratingLabel.text = String(format: "%.1f", rating).replacingOccurrences(of: ".", with: ",")
+//            ratingStackView.isHidden = false
+//
+//            if let ratingCount = poi?.ratingCount {
+//                let opinionsText = AddPlanLocalizationKeys.localized(AddPlanLocalizationKeys.opinions)
+//                reviewLabel.text = "\(ratingCount.formattedWithSeparator) \(opinionsText)"
+//            } else {
+//                reviewLabel.text = ""
+//            }
+//        } else {
+//            ratingStackView.isHidden = true
+//        }
 
         // Configure category
         if let firstCategory = poi?.categories.first {
@@ -370,20 +371,21 @@ class TRPTimelineManualPoiCell: UITableViewCell {
             poiImageView.image = nil
         }
 
-        // Configure rating
-        if let rating = cellData.rating {
-            ratingLabel.text = String(format: "%.1f", rating).replacingOccurrences(of: ".", with: ",")
-            ratingStackView.isHidden = false
-
-            if let ratingCount = cellData.ratingCount {
-                let opinionsText = AddPlanLocalizationKeys.localized(AddPlanLocalizationKeys.opinions)
-                reviewLabel.text = "\(ratingCount.formattedWithSeparator) \(opinionsText)"
-            } else {
-                reviewLabel.text = ""
-            }
-        } else {
-            ratingStackView.isHidden = true
-        }
+        // Configure rating - Hidden
+        ratingStackView.isHidden = true
+//        if let rating = cellData.rating {
+//            ratingLabel.text = String(format: "%.1f", rating).replacingOccurrences(of: ".", with: ",")
+//            ratingStackView.isHidden = false
+//
+//            if let ratingCount = cellData.ratingCount {
+//                let opinionsText = AddPlanLocalizationKeys.localized(AddPlanLocalizationKeys.opinions)
+//                reviewLabel.text = "\(ratingCount.formattedWithSeparator) \(opinionsText)"
+//            } else {
+//                reviewLabel.text = ""
+//            }
+//        } else {
+//            ratingStackView.isHidden = true
+//        }
 
         // Configure category
         if let categoryName = cellData.categoryName, !categoryName.isEmpty {

--- a/TRPCoreKit/ViewController/TimelineItinerary/Cells/TRPTimelineRecommendationsCell.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/Cells/TRPTimelineRecommendationsCell.swift
@@ -477,14 +477,14 @@ class TRPTimelineRecommendationsCell: UITableViewCell {
         titleRow.addSubview(titleLabel)
         titleRow.addSubview(actionButtonsStack)
 
-        // Rating stack - bold 14px for rating, light 14px for reviewCount
+        // Rating stack - Only show for activity steps, hidden for POI steps
         let ratingStack = UIStackView()
         ratingStack.translatesAutoresizingMaskIntoConstraints = false
         ratingStack.axis = .horizontal
-        ratingStack.spacing = 0 // We'll use custom spacing
+        ratingStack.spacing = 0
         ratingStack.alignment = .center
 
-        if let poi = step.poi, let rating = poi.rating {
+        if isActivity, let poi = step.poi, let rating = poi.rating {
             // Rating label - bold 14px primaryText
             let ratingLabel = UILabel()
             ratingLabel.font = FontSet.montserratBold.font(14)
@@ -525,6 +525,7 @@ class TRPTimelineRecommendationsCell: UITableViewCell {
             ratingStack.addArrangedSubview(spacer2)
             ratingStack.addArrangedSubview(reviewLabel)
         }
+        // POI steps: ratingStack remains empty (hidden)
 
         // Get booking product for activity info
         let bookingProduct = step.poi?.bookings?.first?.firstProduct()
@@ -544,8 +545,9 @@ class TRPTimelineRecommendationsCell: UITableViewCell {
             categoryLabel.textColor = ColorSet.fgGreen.uiColor
             categoryLabel.text = TimelineLocalizationKeys.localized(TimelineLocalizationKeys.activityBadge)
         } else {
-            categoryBadge.backgroundColor = ColorSet.bgBlue.uiColor
-            categoryLabel.textColor = ColorSet.fgBlue.uiColor
+            categoryBadge.backgroundColor = ColorSet.neutral200.uiColor
+            categoryLabel.textColor = ColorSet.fgGray.uiColor
+            categoryLabel.font = FontSet.montserratMedium.font(12)
             if let poi = step.poi, let firstCategory = poi.categories.first {
                 categoryLabel.text = firstCategory.name
             } else {
@@ -680,7 +682,9 @@ class TRPTimelineRecommendationsCell: UITableViewCell {
 
         // Build info stack view
         infoStackView.addArrangedSubview(titleRow)
-        infoStackView.addArrangedSubview(ratingStack)
+        if isActivity {
+            infoStackView.addArrangedSubview(ratingStack)
+        }
         infoStackView.addArrangedSubview(categoryBadge)
 
         // For activity: add duration (if exists), cancellation (if exists), then price, then button

--- a/TRPCoreKit/ViewController/TimelineItinerary/PoiDetail/TimelinePoiDetailViewController+Setup.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/PoiDetail/TimelinePoiDetailViewController+Setup.swift
@@ -282,18 +282,19 @@ extension TimelinePoiDetailViewController {
 
         poiNameLabel.text = poi.name
 
-        // Configure Rating
-        if let rating = poi.rating, rating > 0 {
-            ratingLabel.text = String(format: "%.1f", rating)
-
-            let reviewCount = poi.ratingCount ?? 0
-            let opinionsText = AddPlanLocalizationKeys.localized(AddPlanLocalizationKeys.opinions)
-            reviewCountLabel.text = "\(reviewCount) \(opinionsText)"
-
-            ratingContainerView.isHidden = false
-        } else {
-            ratingContainerView.isHidden = true
-        }
+        // Configure Rating - Hidden
+        ratingContainerView.isHidden = true
+//        if let rating = poi.rating, rating > 0 {
+//            ratingLabel.text = String(format: "%.1f", rating)
+//
+//            let reviewCount = poi.ratingCount ?? 0
+//            let opinionsText = AddPlanLocalizationKeys.localized(AddPlanLocalizationKeys.opinions)
+//            reviewCountLabel.text = "\(reviewCount) \(opinionsText)"
+//
+//            ratingContainerView.isHidden = false
+//        } else {
+//            ratingContainerView.isHidden = true
+//        }
 
         // Configure Description and Cuisines
         configureDescriptionAndCuisines(poi: poi)

--- a/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC+Map.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC+Map.swift
@@ -65,13 +65,12 @@ extension TRPTimelineItineraryVC {
     }
     
     private func getMapCenterLocation() -> TRPLocation {
-        // Get center from first segment or use default
-        if let firstPlan = viewModel.getFirstPlan(),
-           let city = firstPlan.city {
-            return city.coordinate
+        // Get center from preferred city (selected day > timeline.city > first plan)
+        if let coordinate = viewModel.getPreferredCityCoordinate() {
+            return coordinate
         }
-        
-        // Default location if no data
+
+        // Default location if no valid city data
         return TRPLocation(lat: 41.9028, lon: 12.4964) // Rome as default
     }
     

--- a/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC+Setup.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC+Setup.swift
@@ -135,10 +135,14 @@ extension TRPTimelineItineraryVC {
         // Use constraint for add plan button bottom that we can animate
         addPlanButtonBottomConstraint = addPlanFloatingButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -24)
 
+        // Map floating button constraints - one for list view, one for map view
+        mapFloatingButtonBottomToAddPlanConstraint = mapFloatingButton.bottomAnchor.constraint(equalTo: addPlanFloatingButton.topAnchor, constant: -16)
+        mapFloatingButtonBottomToPreviewConstraint = mapFloatingButton.bottomAnchor.constraint(equalTo: poiPreviewContainerView.topAnchor, constant: -16)
+
         NSLayoutConstraint.activate([
-            // Map floating button - bottom right, above add plan button
+            // Map floating button - bottom right
             mapFloatingButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
-            mapFloatingButton.bottomAnchor.constraint(equalTo: addPlanFloatingButton.topAnchor, constant: -16),
+            mapFloatingButtonBottomToAddPlanConstraint!, // Default: above add plan button (list view)
 
             // Add plan floating button - bottom right (constraint managed for animation)
             addPlanFloatingButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),

--- a/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC+Setup.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC+Setup.swift
@@ -135,9 +135,10 @@ extension TRPTimelineItineraryVC {
         // Use constraint for add plan button bottom that we can animate
         addPlanButtonBottomConstraint = addPlanFloatingButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -24)
 
-        // Map floating button constraints - one for list view, one for map view
+        // Map floating button constraints - one for list view, one for map view, one for empty days
         mapFloatingButtonBottomToAddPlanConstraint = mapFloatingButton.bottomAnchor.constraint(equalTo: addPlanFloatingButton.topAnchor, constant: -16)
         mapFloatingButtonBottomToPreviewConstraint = mapFloatingButton.bottomAnchor.constraint(equalTo: poiPreviewContainerView.topAnchor, constant: -16)
+        mapFloatingButtonBottomToSafeAreaConstraint = mapFloatingButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -24)
 
         NSLayoutConstraint.activate([
             // Map floating button - bottom right

--- a/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC.swift
@@ -133,6 +133,8 @@ public class TRPTimelineItineraryVC: TRPBaseUIViewController {
     internal var poiPreviewBottomConstraint: NSLayoutConstraint?
     internal var addPlanButtonBottomConstraint: NSLayoutConstraint?
     internal var dayFilterViewTopConstraint: NSLayoutConstraint?
+    internal var mapFloatingButtonBottomToAddPlanConstraint: NSLayoutConstraint?
+    internal var mapFloatingButtonBottomToPreviewConstraint: NSLayoutConstraint?
 
     // Type alias for backward compatibility (model moved to TRPDataLayer/Domain/Models/Timeline/)
     internal typealias TimelineItem = TRPTimelineItem
@@ -227,6 +229,10 @@ public class TRPTimelineItineraryVC: TRPBaseUIViewController {
     }
 
     private func showMapView() {
+        // Update map floating button constraint - position above POI preview
+        mapFloatingButtonBottomToAddPlanConstraint?.isActive = false
+        mapFloatingButtonBottomToPreviewConstraint?.isActive = true
+
         // Hide list, show map
         UIView.animate(withDuration: 0.3) {
             self.tableView.isHidden = true
@@ -243,6 +249,8 @@ public class TRPTimelineItineraryVC: TRPBaseUIViewController {
             // Update floating button icon to list and hide add plan button
             self.mapFloatingButton.updateIcon(TRPImageController().getImage(inFramework: "ic_list", inApp: nil))
             self.addPlanFloatingButton.isHidden = true
+
+            self.view.layoutIfNeeded()
         }
 
         // Update day filter position (move up since savedPlansButton is hidden)
@@ -260,6 +268,10 @@ public class TRPTimelineItineraryVC: TRPBaseUIViewController {
     }
 
     private func showListView() {
+        // Update map floating button constraint - position above add plan button
+        mapFloatingButtonBottomToPreviewConstraint?.isActive = false
+        mapFloatingButtonBottomToAddPlanConstraint?.isActive = true
+
         // Hide map, show list
         UIView.animate(withDuration: 0.3) {
             self.tableView.isHidden = false
@@ -363,7 +375,8 @@ public class TRPTimelineItineraryVC: TRPBaseUIViewController {
 
     internal func updateSavedPlansButton() {
         let hasFavorites = viewModel.hasFavoriteItems()
-        savedPlansButton.isHidden = !hasFavorites
+        let isMapViewActive = !mapContainerView.isHidden
+        savedPlansButton.isHidden = !hasFavorites || isMapViewActive
 
         if hasFavorites {
             let favoriteCount = viewModel.getFavoriteItemsCount()

--- a/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryVC.swift
@@ -135,6 +135,7 @@ public class TRPTimelineItineraryVC: TRPBaseUIViewController {
     internal var dayFilterViewTopConstraint: NSLayoutConstraint?
     internal var mapFloatingButtonBottomToAddPlanConstraint: NSLayoutConstraint?
     internal var mapFloatingButtonBottomToPreviewConstraint: NSLayoutConstraint?
+    internal var mapFloatingButtonBottomToSafeAreaConstraint: NSLayoutConstraint?
 
     // Type alias for backward compatibility (model moved to TRPDataLayer/Domain/Models/Timeline/)
     internal typealias TimelineItem = TRPTimelineItem
@@ -229,8 +230,9 @@ public class TRPTimelineItineraryVC: TRPBaseUIViewController {
     }
 
     private func showMapView() {
-        // Update map floating button constraint - position above POI preview
+        // Update map floating button constraint - will be adjusted in updatePOIPreviewCards based on content
         mapFloatingButtonBottomToAddPlanConstraint?.isActive = false
+        mapFloatingButtonBottomToSafeAreaConstraint?.isActive = false
         mapFloatingButtonBottomToPreviewConstraint?.isActive = true
 
         // Hide list, show map
@@ -270,6 +272,7 @@ public class TRPTimelineItineraryVC: TRPBaseUIViewController {
     private func showListView() {
         // Update map floating button constraint - position above add plan button
         mapFloatingButtonBottomToPreviewConstraint?.isActive = false
+        mapFloatingButtonBottomToSafeAreaConstraint?.isActive = false
         mapFloatingButtonBottomToAddPlanConstraint?.isActive = true
 
         // Hide map, show list
@@ -312,11 +315,17 @@ public class TRPTimelineItineraryVC: TRPBaseUIViewController {
         if mapDisplayItems.isEmpty {
             // Hide completely if no items
             poiPreviewBottomConstraint?.constant = -collectionViewHeight
+            // Position floating button at bottom of safe area (not above hidden preview)
+            mapFloatingButtonBottomToPreviewConstraint?.isActive = false
+            mapFloatingButtonBottomToSafeAreaConstraint?.isActive = true
         } else {
             // Start in expanded state (fully visible)
             isCollectionViewExpanded = true
             poiPreviewBottomConstraint?.constant = expandedOffset
             addPlanButtonBottomConstraint?.constant = expandedOffset - collectionViewHeight - 24
+            // Position floating button above preview cards
+            mapFloatingButtonBottomToSafeAreaConstraint?.isActive = false
+            mapFloatingButtonBottomToPreviewConstraint?.isActive = true
         }
 
         poiPreviewCollectionView.reloadData()

--- a/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryViewModel+MapHelpers.swift
+++ b/TRPCoreKit/ViewController/TimelineItinerary/TRPTimelineItineraryViewModel+MapHelpers.swift
@@ -162,6 +162,31 @@ extension TRPTimelineItineraryViewModel {
         return timeline?.plans?.first
     }
 
+    /// Get the preferred city coordinate for map centering
+    /// Priority: selected day's first city > timeline.city > first plan city > nil
+    public func getPreferredCityCoordinate() -> TRPLocation? {
+        // 1. O gün bulunan ilk plan'ın şehri (seçili gün)
+        if let city = displayItems.first?.city,
+           city.coordinate.lat != 0 || city.coordinate.lon != 0 {
+            return city.coordinate
+        }
+
+        // 2. Timeline'ın ana city'si
+        if let city = timeline?.city,
+           city.coordinate.lat != 0 || city.coordinate.lon != 0 {
+            return city.coordinate
+        }
+
+        // 3. İlk plan'ın city'si (tüm günlerde)
+        if let firstPlan = getFirstPlan(),
+           let city = firstPlan.city,
+           city.coordinate.lat != 0 || city.coordinate.lon != 0 {
+            return city.coordinate
+        }
+
+        return nil
+    }
+
     /// Calculate route for given locations
     public func calculateRoute(for locations: [TRPLocation], completion: @escaping (Route?, Error?) -> Void) {
         guard locations.count > 1 else {


### PR DESCRIPTION
## Summary
- Hide POI ratings in timeline detail and list views (keep for activity steps only)
- Update category badge styling for POI steps (neutral200 background, fgGray text)
- Fix spacing issue between title and category badge when rating is hidden
- Fix map centering on empty days (use selected day's city instead of 0,0)
- Fix floating button position on empty days in map view

## Test plan
- [ ] Open timeline POI detail → rating should be hidden
- [ ] Check activity steps in list → rating should be visible
- [ ] Check POI steps in list → rating should be hidden, no extra spacing
- [ ] Switch to map view on an empty day → map should center on city, not (0,0)
- [ ] On empty day map view → list button should be at bottom, not floating in middle

🤖 Generated with [Claude Code](https://claude.com/claude-code)